### PR TITLE
Change/better error responses

### DIFF
--- a/src/constants/errors.js
+++ b/src/constants/errors.js
@@ -86,7 +86,7 @@ const errorResponses = {
   },
   invalidRentalVerificationCodeError: {
     type: errorTypes.rentalError,
-    code: 'lockedRental',
+    code: 'invalidRentalVerificationCode',
     message: 'The listing rental verification code is invalid',
     extra: null,
   },

--- a/src/constants/errors.js
+++ b/src/constants/errors.js
@@ -1,0 +1,102 @@
+const errorTypes = {
+  apiConnectionError: 'apiConnectionError',
+  apiError: 'apiError',
+  authenticationError: 'authenticationError',
+  idempotencyError: 'idempotencyError',
+  invalidRequestError: 'invalidRequestError',
+  rateLimitError: 'rateLimitError',
+  validationError: 'validationError',
+  enquiryError: 'enquiryError',
+  listingError: 'listingError',
+  rentalError: 'rentalError',
+};
+
+const errorResponses = {
+  validationParamError: {
+    type: errorTypes.invalidRequestError,
+    code: 'paramError',
+    message: 'Invalid parameter provided in the request path',
+    extra: null,
+  },
+  validationQueryError: {
+    type: errorTypes.invalidRequestError,
+    code: 'queryError',
+    message: 'Invalid parameter provided in the request queries',
+    extra: null,
+  },
+  validationBodyError: {
+    type: errorTypes.invalidRequestError,
+    code: 'bodyError',
+    message: 'Invalid parameter provided in the request body',
+    extra: null,
+  },
+  userAlreadyExistsError: {
+    type: errorTypes.validationError,
+    code: 'userAlreadyExists',
+    message: 'A user with the provided credentials already exists',
+    extra: null,
+  },
+  userNotFoundError: {
+    type: errorTypes.validationError,
+    code: 'userNotFound',
+    message: 'A user with the provided credentials does not exist',
+    extra: null,
+  },
+  userNotAuthenticatedError: {
+    type: errorTypes.authenticationError,
+    code: 'userNotAuthenticated',
+    message: 'Request is not authenticated with a valid user',
+    extra: null,
+  },
+  invalidChatParticipantError: {
+    type: errorTypes.validationError,
+    code: 'invalidChatParticipant',
+    message: 'Invalid chat participant ID',
+    extra: null,
+  },
+  lockedEnquiryError: {
+    type: errorTypes.enquiryError,
+    code: 'lockedEnquiry',
+    message: 'The listing enquiry is locked',
+    extra: null,
+  },
+  previousPendingReviewEnquiryError: {
+    type: errorTypes.enquiryError,
+    code: 'lockedListing',
+    message: 'Previous listing enquiry is pending review',
+    extra: null,
+  },
+  unprocessableLocationAddress: {
+    type: errorTypes.listingError,
+    code: 'unprocessableLocationAddress',
+    message: 'The location address cannot be processed',
+    extra: null,
+  },
+  lockedListingError: {
+    type: errorTypes.listingError,
+    code: 'lockedListing',
+    message: 'The listing is locked',
+    extra: null,
+  },
+  lockedRentalError: {
+    type: errorTypes.rentalError,
+    code: 'lockedRental',
+    message: 'The listing rental is locked',
+    extra: null,
+  },
+  invalidRentalVerificationCodeError: {
+    type: errorTypes.rentalError,
+    code: 'lockedRental',
+    message: 'The listing rental verification code is invalid',
+    extra: null,
+  },
+};
+
+module.exports = {
+  errorTypes: {
+    ...errorTypes,
+  },
+  errorResponses: {
+    ...errorResponses,
+  },
+};

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -1,16 +1,18 @@
 const BaseController = require('./base');
 const authUtils = require('../utils/auth');
 const models = require('../models');
+const { errorResponses } = require('../constants/errors');
 
 class AuthController extends BaseController {
   /**
    * Create a local user (register).
    */
   async createLocalUserItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.body?.error) {
-      errorResponseObj.validation.body = req.validated.body.error;
+      errorResponseObj = errorResponses.validationBodyError;
+      errorResponseObj.extra = req.validated.body.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -23,7 +25,7 @@ class AuthController extends BaseController {
       });
 
       if (foundUserObj) {
-        return this.conflict(res, 'User already exists');
+        return this.conflict(res, errorResponses.userAlreadyExistsError);
       }
 
       const newUserObj = await models.sequelize.transaction(async (t) => {
@@ -81,10 +83,11 @@ class AuthController extends BaseController {
    * Retrieve (POST) a local user (login).
    */
   async retrieveLocalUserItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.body?.error) {
-      errorResponseObj.validation.body = req.validated.body.error;
+      errorResponseObj = errorResponses.validationBodyError;
+      errorResponseObj.extra = req.validated.body.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -129,7 +132,7 @@ class AuthController extends BaseController {
         return this.fail(res, 'Error creating token');
       }
 
-      return this.unauthorized(res, null);
+      return this.notFound(res, errorResponses.userNotFoundError);
     } catch (error) {
       return this.fail(res, error);
     }
@@ -164,7 +167,7 @@ class AuthController extends BaseController {
   }
 
   notAuthenticated(req, res) {
-    return this.unauthorized(res, 'Not authenticated');
+    return this.unauthorized(res, errorResponses.userNotAuthenticatedError);
   }
 }
 

--- a/src/controllers/chat.js
+++ b/src/controllers/chat.js
@@ -2,16 +2,18 @@ const BaseController = require('./base');
 const models = require('../models');
 const apiConfig = require('../configs/api');
 const socket = require('../socket-io');
+const { errorResponses } = require('../constants/errors');
 
 class ChatController extends BaseController {
   /**
    * Create a chat thread.
    */
   async createChatThreadItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.body?.error) {
-      errorResponseObj.validation.body = req.validated.body.error;
+      errorResponseObj = errorResponses.validationBodyError;
+      errorResponseObj.extra = req.validated.body.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -22,11 +24,11 @@ class ChatController extends BaseController {
       );
 
       if (!otherUserObj) {
-        return this.unprocessableEntity(res, 'Invalid participant id');
+        return this.badRequest(res, errorResponses.invalidChatParticipantError);
       }
 
       if (otherUserObj.id === req.user.id) {
-        return this.unprocessableEntity(res, 'Invalid participant id');
+        return this.badRequest(res, errorResponses.invalidChatParticipantError);
       }
 
       let chatThreadObj;
@@ -100,10 +102,11 @@ class ChatController extends BaseController {
    * Retrieve a list of chat threads.
    */
   async retrieveChatThreadList(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.query?.error) {
-      errorResponseObj.validation.query = req.validated.query.error;
+      errorResponseObj = errorResponses.validationQueryError;
+      errorResponseObj.extra = req.validated.query.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -220,10 +223,11 @@ class ChatController extends BaseController {
    * with params `chatTheadId`.
    */
   async retrieveChatThreadItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.params?.error) {
-      errorResponseObj.validation.params = req.validated.params.error;
+      errorResponseObj = errorResponses.validationParamError;
+      errorResponseObj.extra = req.validated.params.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -286,16 +290,18 @@ class ChatController extends BaseController {
    * with params `chatTheadId`.
    */
   async retrieveChatMessageList(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.params?.error) {
-      errorResponseObj.validation.params = req.validated.params.error;
+      errorResponseObj = errorResponses.validationParamError;
+      errorResponseObj.extra = req.validated.params.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
 
     if (req.validated.query?.error) {
-      errorResponseObj.validation.query = req.validated.query.error;
+      errorResponseObj = errorResponses.validationQueryError;
+      errorResponseObj.extra = req.validated.query.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -435,16 +441,18 @@ class ChatController extends BaseController {
    * with params `chatTheadId`.
    */
   async createChatMessageItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.params?.error) {
-      errorResponseObj.validation.params = req.validated.params.error;
+      errorResponseObj = errorResponses.validationParamError;
+      errorResponseObj.extra = req.validated.params.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
 
     if (req.validated.body?.error) {
-      errorResponseObj.validation.body = req.validated.body.error;
+      errorResponseObj = errorResponses.validationBodyError;
+      errorResponseObj.extra = req.validated.body.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -556,10 +564,11 @@ class ChatController extends BaseController {
    * with params `chatTheadId` and `chatMessageId`.
    */
   async retrieveChatMessageItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.params?.error) {
-      errorResponseObj.validation.params = req.validated.params.error;
+      errorResponseObj = errorResponses.validationParamError;
+      errorResponseObj.extra = req.validated.params.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }

--- a/src/controllers/enquiry.js
+++ b/src/controllers/enquiry.js
@@ -1,5 +1,6 @@
 const BaseController = require('./base');
 const models = require('../models');
+const { errorResponses } = require('../constants/errors');
 
 class EnquiryController extends BaseController {
   /**
@@ -7,10 +8,11 @@ class EnquiryController extends BaseController {
    * with params `enquiryId`.
    */
   async retrieveListingEnquiryItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.params?.error) {
-      errorResponseObj.validation.params = req.validated.params.error;
+      errorResponseObj = errorResponses.validationParamError;
+      errorResponseObj.extra = req.validated.params.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -81,16 +83,18 @@ class EnquiryController extends BaseController {
    * with params `enquiryId`.
    */
   async updateListingEnquiryItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.params?.error) {
-      errorResponseObj.validation.params = req.validated.params.error;
+      errorResponseObj = errorResponses.validationParamError;
+      errorResponseObj.extra = req.validated.params.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
 
     if (req.validated.body?.error) {
-      errorResponseObj.validation.body = req.validated.body.error;
+      errorResponseObj = errorResponses.validationBodyError;
+      errorResponseObj.extra = req.validated.body.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -126,10 +130,10 @@ class EnquiryController extends BaseController {
             (status) => enquiryObj.enquiryStatus === status
           )
         ) {
-          return this.forbidden(
-            res,
-            `The listing enquiry is locked (status: ${enquiryObj.enquiryStatus})`
-          );
+          errorResponseObj = errorResponses.lockedEnquiryError;
+          errorResponseObj.extra = { enquiryStatus: enquiryObj.enquiryStatus };
+
+          return this.forbidden(res, errorResponseObj);
         }
 
         if (
@@ -179,10 +183,11 @@ class EnquiryController extends BaseController {
    * with params `enquiryId`.
    */
   async deleteListingEnquiryItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.params?.error) {
-      errorResponseObj.validation.params = req.validated.params.error;
+      errorResponseObj = errorResponses.validationParamError;
+      errorResponseObj.extra = req.validated.params.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -210,10 +215,10 @@ class EnquiryController extends BaseController {
             (status) => enquiryObj.enquiryStatus === status
           )
         ) {
-          return this.forbidden(
-            res,
-            `The listing enquiry is locked (status: ${enquiryObj.enquiryStatus})`
-          );
+          errorResponseObj = errorResponses.lockedEnquiryError;
+          errorResponseObj.extra = { enquiryStatus: enquiryObj.enquiryStatus };
+
+          return this.forbidden(res, errorResponseObj);
         }
 
         await enquiryObj.destroy();
@@ -232,10 +237,11 @@ class EnquiryController extends BaseController {
    * with params `enquiryId`.
    */
   async acceptListingEnquiryItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.params?.error) {
-      errorResponseObj.validation.params = req.validated.params.error;
+      errorResponseObj = errorResponses.validationParamError;
+      errorResponseObj.extra = req.validated.params.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -273,10 +279,10 @@ class EnquiryController extends BaseController {
             (status) => enquiryObj.enquiryStatus === status
           )
         ) {
-          return this.forbidden(
-            res,
-            `The listing enquiry is locked (status: ${enquiryObj.enquiryStatus})`
-          );
+          errorResponseObj = errorResponses.lockedEnquiryError;
+          errorResponseObj.extra = { enquiryStatus: enquiryObj.enquiryStatus };
+
+          return this.forbidden(res, errorResponseObj);
         }
 
         const newRentalObj = await models.sequelize.transaction(async (t) => {
@@ -332,10 +338,11 @@ class EnquiryController extends BaseController {
    * with params `enquiryId`.
    */
   async rejectListingEnquiryItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.params?.error) {
-      errorResponseObj.validation.params = req.validated.params.error;
+      errorResponseObj = errorResponses.validationParamError;
+      errorResponseObj.extra = req.validated.params.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -367,10 +374,10 @@ class EnquiryController extends BaseController {
             (status) => enquiryObj.enquiryStatus === status
           )
         ) {
-          return this.forbidden(
-            res,
-            `The listing enquiry is locked (status: ${enquiryObj.enquiryStatus})`
-          );
+          errorResponseObj = errorResponses.lockedEnquiryError;
+          errorResponseObj.extra = { enquiryStatus: enquiryObj.enquiryStatus };
+
+          return this.forbidden(res, errorResponseObj);
         }
 
         enquiryObj.enquiryStatus = 'rejected';
@@ -407,10 +414,11 @@ class EnquiryController extends BaseController {
    * with params `enquiryId`.
    */
   async cancelListingEnquiryItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.params?.error) {
-      errorResponseObj.validation.params = req.validated.params.error;
+      errorResponseObj = errorResponses.validationParamError;
+      errorResponseObj.extra = req.validated.params.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -456,10 +464,10 @@ class EnquiryController extends BaseController {
             (status) => enquiryObj.enquiryStatus === status
           )
         ) {
-          return this.forbidden(
-            res,
-            `The listing enquiry is locked (status: ${enquiryObj.enquiryStatus})`
-          );
+          errorResponseObj = errorResponses.lockedEnquiryError;
+          errorResponseObj.extra = { enquiryStatus: enquiryObj.enquiryStatus };
+
+          return this.forbidden(res, errorResponseObj);
         }
 
         await models.sequelize.transaction(async (t) => {

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -1,5 +1,6 @@
 const models = require('../models');
 const BaseController = require('./base');
+const { errorResponses } = require('../constants/errors');
 
 class UserController extends BaseController {
   /**
@@ -7,10 +8,11 @@ class UserController extends BaseController {
    * with params `userId`.
    */
   async retrieveUserItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.params?.error) {
-      errorResponseObj.validation.params = req.validated.params.error;
+      errorResponseObj = errorResponses.validationParamError;
+      errorResponseObj.extra = req.validated.params.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
@@ -41,16 +43,18 @@ class UserController extends BaseController {
    * with params `userId`.
    */
   async updateUserItem(req, res) {
-    const errorResponseObj = { validation: {} };
+    let errorResponseObj;
 
     if (req.validated.params?.error) {
-      errorResponseObj.validation.params = req.validated.params.error;
+      errorResponseObj = errorResponses.validationParamError;
+      errorResponseObj.extra = req.validated.params.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }
 
     if (req.validated.body?.error) {
-      errorResponseObj.validation.body = req.validated.body.error;
+      errorResponseObj = errorResponses.validationBodyError;
+      errorResponseObj.extra = req.validated.body.error;
 
       return this.unprocessableEntity(res, errorResponseObj);
     }


### PR DESCRIPTION
# Better error responses

Json responses when errors occur now return in a format partially inspired by Stripe's API. 

Heres an example error response;

```
{
    "success": false,
    "error": {
        "type": "enquiryError",
        "code": "lockedListing",
        "message": "Previous enquiry is pending review",
        "extra": {
            "enquiryId": [
                "2cc866ed-b615-4770-a3be-bc146ad3a3f2"
            ]
        }
    },
    "data": null
}
```