### PR TITLE
Addition/utils api unit tests

### DIFF
--- a/test/utils/api.unit.test.js
+++ b/test/utils/api.unit.test.js
@@ -9,4 +9,32 @@ describe('Api utils tests', () => {
     expect(apiUtils.makeSlug('')).toBe('');
     expect(apiUtils.makeSlug(null)).toBe('');
   });
+  it('Clean string test', () => {
+    expect(apiUtils.cleanString('QWERTYqwerty')).toBe('QWERTYqwerty');
+    expect(apiUtils.cleanString('123abcABC')).toBe('123abcABC');
+    expect(apiUtils.cleanString('T@$t %tr1ng#')).toBe('Tt tr1ng');
+    expect(apiUtils.cleanString('!@#$%^&*()-+=<>?;:"][{}|~,./', 6)).toBe('');
+    expect(apiUtils.cleanString('')).toBe('');
+    expect(apiUtils.cleanString(null)).toBe('');
+  });
+  it('Truncate string test', () => {
+    expect(apiUtils.truncateString('Test this', 13)).toBe('Test this');
+    expect(apiUtils.truncateString('Test this', 12)).toBe('Test this');
+    expect(apiUtils.truncateString('Test this', 11)).toBe('Test this');
+    expect(apiUtils.truncateString('Test this', 10)).toBe('Test this');
+    expect(apiUtils.truncateString('Test this', 9)).toBe('Test this');
+    expect(apiUtils.truncateString('Test this', 8)).toBe('Test ...');
+    expect(apiUtils.truncateString('Test this', 7)).toBe('Test...');
+    expect(apiUtils.truncateString('Test this', 6)).toBe('Tes...');
+    expect(apiUtils.truncateString('Test this', 5)).toBe('Te...');
+    expect(apiUtils.truncateString('Test this', 4)).toBe('T...');
+    expect(apiUtils.truncateString('Test this', 3)).toBe('Tes [...]');
+    expect(apiUtils.truncateString('Test this', 2)).toBe('Te [...]');
+    expect(apiUtils.truncateString('Test this', 1)).toBe('T [...]');
+    expect(apiUtils.truncateString('Test this', 0)).toBe(' [...]');
+    expect(apiUtils.truncateString('Test this', 7, '!')).toBe('Test!!!');
+    expect(apiUtils.truncateString('Test this', 7, '!', 5)).toBe('Te!!!!!');
+    expect(apiUtils.truncateString('')).toBe('');
+    expect(apiUtils.truncateString(null)).toBe('');
+  });
 });


### PR DESCRIPTION
Added unit tests for truncate string and clean string.
test/utils/api.unit.test.js revealed an error: expect(apiUtils.truncateString('Test this', 8)).toBe('Test ...'); where output was 'Test...' instead of 'Test ...'. Fixed this by removing trim() call to truncatedString.

OS: Tested and developed on Windows 10
