### PR TITLE
Fixed truncated string to produce expected output.

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -45,11 +45,11 @@ module.exports = {
     let truncatedString;
 
     if (width - charCount <= 0) {
-      truncatedString = inputText.slice(0, width).trim();
+      truncatedString = inputText.slice(0, width);
 
       result = `${truncatedString} [${char.repeat(charCount)}]`;
     } else {
-      truncatedString = inputText.slice(0, width - charCount).trim();
+      truncatedString = inputText.slice(0, width - charCount);
 
       result = `${truncatedString}${char.repeat(charCount)}`;
     }


### PR DESCRIPTION
Removed trim() calls to allow whitespaces in truncated string in reflection to unit tests: test/utils/api.unit.test.js.

OS: Tested and developed on Windows 10
